### PR TITLE
OFS-188: base mutations for contract details

### DIFF
--- a/contract/gql/gql_mutations/contract_details_mutations.py
+++ b/contract/gql/gql_mutations/contract_details_mutations.py
@@ -1,0 +1,33 @@
+from core.gql.gql_mutations import DeleteInputType
+from core.gql.gql_mutations.base_mutation import BaseMutation, BaseDeleteMutation, \
+    BaseHistoryModelCreateMutationMixin, BaseHistoryModelUpdateMutationMixin, \
+    BaseHistoryModelDeleteMutationMixin
+from contract.gql.gql_mutations import ContractDetailsCreateInputType, ContractDetailsUpdateInputType
+from contract.models import ContractDetails
+
+
+class CreateContractDetailsMutation(BaseHistoryModelCreateMutationMixin, BaseMutation):
+    _mutation_class = "ContractDetailsMutation"
+    _mutation_module = "contract"
+    _model = ContractDetails
+
+    class Input(ContractDetailsCreateInputType):
+        pass
+
+
+class UpdateContractDetailsMutation(BaseHistoryModelUpdateMutationMixin, BaseMutation):
+    _mutation_class = "ContractDetailsMutation"
+    _mutation_module = "contract"
+    _model = ContractDetails
+
+    class Input(ContractDetailsUpdateInputType):
+        pass
+
+
+class DeleteContractDetailsMutation(BaseHistoryModelDeleteMutationMixin, BaseDeleteMutation):
+    _mutation_class = "ContractDetailsMutation"
+    _mutation_module = "contract"
+    _model = ContractDetails
+
+    class Input(DeleteInputType):
+        pass

--- a/contract/gql/gql_mutations/contract_mutations.py
+++ b/contract/gql/gql_mutations/contract_mutations.py
@@ -1,8 +1,8 @@
 from core.gql.gql_mutations.base_mutation  import BaseMutation, BaseDeleteMutation
-from .mutations import ContractCreateMutationMixin
+from .mutations import ContractCreateMutationMixin, ContractUpdateMutationMixin
 
 from contract.models import Contract
-from contract.gql.gql_mutations.input_types import ContractCreateInputType
+from contract.gql.gql_mutations.input_types import ContractCreateInputType, ContractUpdateInputType
 
 
 class CreateContractMutation(ContractCreateMutationMixin, BaseMutation):
@@ -11,4 +11,13 @@ class CreateContractMutation(ContractCreateMutationMixin, BaseMutation):
     _model = Contract
 
     class Input(ContractCreateInputType):
+        pass
+
+
+class UpdateContractMutation(ContractUpdateMutationMixin, BaseMutation):
+    _mutation_class = "UpdateContractMutation"
+    _mutation_module = "contract"
+    _model = Contract
+
+    class Input(ContractUpdateInputType):
         pass

--- a/contract/gql/gql_mutations/input_types.py
+++ b/contract/gql/gql_mutations/input_types.py
@@ -20,3 +20,23 @@ class ContractCreateInputType(OpenIMISMutation.Input):
     date_valid_from = graphene.Date(required=False)
     date_valid_to = graphene.Date(required=False)
     json_ext = graphene.types.json.JSONString(required=False)
+
+
+class ContractUpdateInputType(OpenIMISMutation.Input):
+    id = graphene.UUID(required=True)
+    code = graphene.String(required=False, max_length=32)
+    policy_holder_id = graphene.UUID(required=False)
+
+    amount_notified = graphene.Decimal(max_digits=18, decimal_places=2, required=False)
+    amount_rectified = graphene.Decimal(max_digits=18, decimal_places=2, required=False)
+    amount_due = graphene.Decimal(max_digits=18, decimal_places=2, required=False)
+
+    date_approved = graphene.DateTime(required=False)
+    date_payment_due = graphene.Date(required=False)
+
+    payment_reference = graphene.String(required=False)
+    amendment = graphene.Int(required=False)
+
+    date_valid_from = graphene.Date(required=False)
+    date_valid_to = graphene.Date(required=False)
+    json_ext = graphene.types.json.JSONString(required=False)

--- a/contract/gql/gql_mutations/input_types.py
+++ b/contract/gql/gql_mutations/input_types.py
@@ -40,3 +40,21 @@ class ContractUpdateInputType(OpenIMISMutation.Input):
     date_valid_from = graphene.Date(required=False)
     date_valid_to = graphene.Date(required=False)
     json_ext = graphene.types.json.JSONString(required=False)
+
+
+class ContractDetailsCreateInputType(OpenIMISMutation.Input):
+    id = graphene.UUID(required=False)
+    contract_id = graphene.UUID(required=True)
+    insuree_id = graphene.Int(required=True)
+    contribution_plan_bundle_id = graphene.UUID(required=True)
+    json_ext = graphene.types.json.JSONString(required=False)
+    json_param = graphene.types.json.JSONString(required=False)
+
+
+class ContractDetailsUpdateInputType(OpenIMISMutation.Input):
+    id = graphene.UUID(required=True)
+    contract_id = graphene.UUID(required=False)
+    insuree_id = graphene.Int(required=False)
+    contribution_plan_bundle_id = graphene.UUID(required=False)
+    json_ext = graphene.types.json.JSONString(required=False)
+    json_param = graphene.types.json.JSONString(required=False)

--- a/contract/gql/gql_mutations/mutations.py
+++ b/contract/gql/gql_mutations/mutations.py
@@ -23,10 +23,38 @@ class ContractCreateMutationMixin:
             data.pop('client_mutation_id')
         if "client_mutation_label" in data:
             data.pop('client_mutation_label')
-        cls.create_contract(user=user, contract=data)
+        output = cls.create_contract(user=user, contract=data)
+        return None if output["success"] else f"Error! - {output['message']}: {output['detail']}"
 
     @classmethod
     def create_contract(cls, user, contract):
         contract_service = ContractService(user=user)
         output_data = contract_service.create(contract=contract)
+        return output_data
+
+
+class ContractUpdateMutationMixin:
+
+    @property
+    def _model(self):
+        raise NotImplementedError()
+
+    @classmethod
+    def _validate_mutation(cls, user, **data):
+        if type(user) is AnonymousUser or not user.id or not user.has_perms(ContractConfig.gql_mutation_update_contract_perms):
+            raise ValidationError("mutation.authentication_required")
+
+    @classmethod
+    def _mutate(cls, user, **data):
+        if "client_mutation_id" in data:
+            data.pop('client_mutation_id')
+        if "client_mutation_label" in data:
+            data.pop('client_mutation_label')
+        output = cls.update_contract(user=user, contract=data)
+        return None if output["success"] else f"Error! - {output['message']}: {output['detail']}"
+
+    @classmethod
+    def update_contract(cls, user, contract):
+        contract_service = ContractService(user=user)
+        output_data = contract_service.update(contract=contract)
         return output_data

--- a/contract/schema.py
+++ b/contract/schema.py
@@ -7,7 +7,8 @@ from contract.models import Contract, ContractDetails, \
 from contract.gql.gql_types import ContractGQLType, ContractDetailsGQLType, \
     ContractContributionPlanDetailsGQLType
 
-from contract.gql.gql_mutations.contract_mutations import CreateContractMutation
+from contract.gql.gql_mutations.contract_mutations import CreateContractMutation, \
+    UpdateContractMutation
 from contract.apps import ContractConfig
 
 class Query(graphene.ObjectType):
@@ -76,3 +77,4 @@ class Query(graphene.ObjectType):
 
 class Mutation(graphene.ObjectType):
     create_contract = CreateContractMutation.Field()
+    update_contract = UpdateContractMutation.Field()

--- a/contract/schema.py
+++ b/contract/schema.py
@@ -9,6 +9,9 @@ from contract.gql.gql_types import ContractGQLType, ContractDetailsGQLType, \
 
 from contract.gql.gql_mutations.contract_mutations import CreateContractMutation, \
     UpdateContractMutation
+from contract.gql.gql_mutations.contract_details_mutations import CreateContractDetailsMutation, \
+    UpdateContractDetailsMutation, DeleteContractDetailsMutation
+
 from contract.apps import ContractConfig
 
 class Query(graphene.ObjectType):
@@ -78,3 +81,7 @@ class Query(graphene.ObjectType):
 class Mutation(graphene.ObjectType):
     create_contract = CreateContractMutation.Field()
     update_contract = UpdateContractMutation.Field()
+
+    create_contract_details = CreateContractDetailsMutation.Field()
+    update_contract_details = UpdateContractDetailsMutation.Field()
+    delete_contract_details = DeleteContractDetailsMutation.Field()

--- a/contract/tests/services/services_tests.py
+++ b/contract/tests/services/services_tests.py
@@ -89,3 +89,43 @@ class ServiceTestPolicyHolder(TestCase):
                  response['data']['amendment'],
             )
         )
+
+    def test_contract_create_update_with_policy_holder(self):
+        # create contract for contract with policy holder with two phinsuree
+        policy_holder = create_test_policy_holder()
+
+        # create contribution plan etc
+        contribution_plan_bundle = create_test_contribution_plan_bundle()
+        contribution_plan = create_test_contribution_plan()
+        contribution_plan_bundle_details = create_test_contribution_plan_bundle_details(
+            contribution_plan=contribution_plan, contribution_plan_bundle=contribution_plan_bundle
+        )
+
+        # create policy holder insuree
+        for i in range(0, 3):
+            create_test_policy_holder_insuree(policy_holder=policy_holder,
+                                              contribution_plan_bundle=contribution_plan_bundle)
+
+        contract = {
+            "code": "CTS",
+            "policy_holder_id": str(policy_holder.id)
+        }
+        response = self.contract_service.create(contract)
+        contract_id = str(response["data"]["id"])
+        expected_amount_notified = response["data"]["amount_notified"] + 400.50
+
+        contract = {
+            "id": contract_id,
+            "amount_notified": expected_amount_notified,
+        }
+        response = self.contract_service.update(contract)
+        # tear down the test data
+        ContractDetails.objects.filter(contract_id=contract_id).delete()
+        Contract.objects.filter(id=contract_id).delete()
+        PolicyHolderInsuree.objects.filter(policy_holder_id=str(policy_holder.id)).delete()
+        PolicyHolder.objects.filter(id=policy_holder.id).delete()
+        ContributionPlanBundleDetails.objects.filter(id=contribution_plan_bundle_details.id).delete()
+        ContributionPlanBundle.objects.filter(id=contribution_plan_bundle.id).delete()
+        ContributionPlan.objects.filter(id=contribution_plan.id).delete()
+
+        self.assertEqual(expected_amount_notified, response['data']['amount_notified'])


### PR DESCRIPTION
IMPORTANT! This should be merged after accepting and merging this PR related to both "update contract" mutation and  service and add another perms in contract module.
#8, #9 and https://github.com/openimis/openimis-be-contract_py/pull/10 . Later after merging pull #8, #9, https://github.com/openimis/openimis-be-contract_py/pull/10 I will change the status of this pull request from "Draft" to the "Open".

The order of merging PR:
    
    #8
    #9
    #10 
    this one

In that PR I want to add the "contracDetails" mutation to allow some operations during developing some use cases in frontend related to the "ContractDetails" Tab.