### PR TITLE
OFS-135: 'delete contract' service

### DIFF
--- a/contract/services.py
+++ b/contract/services.py
@@ -153,7 +153,19 @@ class Contract(object):
         pass
 
     def delete(self, contract):
-        pass
+        try:
+            # check rights for delete contract
+            if not self.user.has_perms(ContractConfig.gql_mutation_delete_contract_perms):
+                raise PermissionError("Unauthorized")
+            contract_to_delete = ContractModel.objects.filter(id=contract["id"]).first()
+            contract_to_delete.delete(username=self.user.username)
+            return {
+                "success": True,
+                "message": "Ok",
+                "detail": "",
+            }
+        except Exception as exc:
+            return _output_exception(model_name="Contract", method="delete", exception=exc)
 
 
 class ContractDetails(object):

--- a/contract/services.py
+++ b/contract/services.py
@@ -158,6 +158,9 @@ class Contract(object):
             if not self.user.has_perms(ContractConfig.gql_mutation_delete_contract_perms):
                 raise PermissionError("Unauthorized")
             contract_to_delete = ContractModel.objects.filter(id=contract["id"]).first()
+            # block deleting contract not in Updateable or Approvable state
+            if self.__check_rights_by_status(contract_to_delete.state) == "cannot_update":
+                raise ContractUpdateError("Contract in that state cannot be deleted")
             contract_to_delete.delete(username=self.user.username)
             return {
                 "success": True,

--- a/contract/tests/services/services_tests.py
+++ b/contract/tests/services/services_tests.py
@@ -90,7 +90,7 @@ class ServiceTestPolicyHolder(TestCase):
             )
         )
 
-    def test_contract_create_update_with_policy_holder(self):
+    def test_contract_create_update_delete_with_policy_holder(self):
         # create contract for contract with policy holder with two phinsuree
         policy_holder = create_test_policy_holder()
 
@@ -119,6 +119,14 @@ class ServiceTestPolicyHolder(TestCase):
             "amount_notified": expected_amount_notified,
         }
         response = self.contract_service.update(contract)
+        updated_amount_notified = response['data']['amount_notified']
+
+        contract = {
+            "id": contract_id,
+        }
+        response = self.contract_service.delete(contract)
+        is_deleted = response['success']
+
         # tear down the test data
         ContractDetails.objects.filter(contract_id=contract_id).delete()
         Contract.objects.filter(id=contract_id).delete()
@@ -128,4 +136,7 @@ class ServiceTestPolicyHolder(TestCase):
         ContributionPlanBundle.objects.filter(id=contribution_plan_bundle.id).delete()
         ContributionPlan.objects.filter(id=contribution_plan.id).delete()
 
-        self.assertEqual(expected_amount_notified, response['data']['amount_notified'])
+        self.assertEqual(
+            (expected_amount_notified, True),
+            (updated_amount_notified, is_deleted)
+        )


### PR DESCRIPTION
IMPORTANT! This should be merged after accepting and merging this PR related to base mutation for ContractDetails, both "update contract" mutation and service and add another perms in contract module.
#8, #9 and #10, https://github.com/openimis/openimis-be-contract_py/pull/11 . Later after merging pull #8, #9, #10, https://github.com/openimis/openimis-be-contract_py/pull/11  I will change the status of this pull request from "Draft" to the "Open".

The order of merging PR:

#8
#9
#10 
#11 
this one

In that PR I want to add the 'contract delete' service.