### PR TITLE
OFS-128: delete contract

### DIFF
--- a/contract/gql/gql_mutations/contract_mutations.py
+++ b/contract/gql/gql_mutations/contract_mutations.py
@@ -1,6 +1,7 @@
+from core.gql.gql_mutations import DeleteInputType
 from core.gql.gql_mutations.base_mutation  import BaseMutation, BaseDeleteMutation
-from .mutations import ContractCreateMutationMixin, ContractUpdateMutationMixin
-
+from .mutations import ContractCreateMutationMixin, ContractUpdateMutationMixin, \
+    ContractDeleteMutationMixin
 from contract.models import Contract
 from contract.gql.gql_mutations.input_types import ContractCreateInputType, ContractUpdateInputType
 
@@ -20,4 +21,12 @@ class UpdateContractMutation(ContractUpdateMutationMixin, BaseMutation):
     _model = Contract
 
     class Input(ContractUpdateInputType):
+        pass
+
+class DeleteContractMutation(ContractDeleteMutationMixin, BaseDeleteMutation):
+    _mutation_class = "DeleteContractMutation"
+    _mutation_module = "contract"
+    _model = Contract
+
+    class Input(DeleteInputType):
         pass

--- a/contract/schema.py
+++ b/contract/schema.py
@@ -8,7 +8,7 @@ from contract.gql.gql_types import ContractGQLType, ContractDetailsGQLType, \
     ContractContributionPlanDetailsGQLType
 
 from contract.gql.gql_mutations.contract_mutations import CreateContractMutation, \
-    UpdateContractMutation
+    UpdateContractMutation, DeleteContractMutation
 from contract.gql.gql_mutations.contract_details_mutations import CreateContractDetailsMutation, \
     UpdateContractDetailsMutation, DeleteContractDetailsMutation
 
@@ -81,6 +81,7 @@ class Query(graphene.ObjectType):
 class Mutation(graphene.ObjectType):
     create_contract = CreateContractMutation.Field()
     update_contract = UpdateContractMutation.Field()
+    delete_contract = DeleteContractMutation.Field()
 
     create_contract_details = CreateContractDetailsMutation.Field()
     update_contract_details = UpdateContractDetailsMutation.Field()

--- a/contract/services.py
+++ b/contract/services.py
@@ -153,7 +153,19 @@ class Contract(object):
         pass
 
     def delete(self, contract):
-        pass
+        try:
+            # check rights for delete contract
+            if not self.user.has_perms(ContractConfig.gql_mutation_delete_contract_perms):
+                raise PermissionError("Unauthorized")
+            contract_to_delete = ContractModel.objects.filter(id=contract["id"]).first()
+            contract_to_delete.delete(username=self.user.username)
+            return {
+                "success": True,
+                "message": "Ok",
+                "detail": "",
+            }
+        except Exception as exc:
+            return _output_exception(model_name="Contract", method="delete", exception=exc)
 
 
 class ContractDetails(object):

--- a/contract/tests/gql_tests/mutation_create_tests.py
+++ b/contract/tests/gql_tests/mutation_create_tests.py
@@ -142,6 +142,14 @@ class MutationTestCreate(TestCase):
             "contract",
             params={"id": str(converted_id)},
         )["edges"]
+        updated_amount_notified = result[0]['node']['amountNotified']
+
+        self.add_mutation("deleteContract", {"uuids": [str(converted_id)]})
+        result = self.find_by_exact_attributes_query(
+            "contract",
+            params={"id": str(converted_id), "isDeleted": True},
+        )["edges"]
+        is_deleted = result[0]['node']['isDeleted']
 
         # tear down the test data
         ContractDetails.objects.filter(contract_id=str(converted_id)).delete()
@@ -155,10 +163,12 @@ class MutationTestCreate(TestCase):
         self.assertEqual(
             (
                 expected_amount_notified,
+                True
             )
             ,
             (
-                result[0]['node']['amountNotified'],
+                updated_amount_notified,
+                is_deleted
             )
         )
 

--- a/contract/tests/services/services_tests.py
+++ b/contract/tests/services/services_tests.py
@@ -90,7 +90,7 @@ class ServiceTestPolicyHolder(TestCase):
             )
         )
 
-    def test_contract_create_update_with_policy_holder(self):
+    def test_contract_create_update_delete_with_policy_holder(self):
         # create contract for contract with policy holder with two phinsuree
         policy_holder = create_test_policy_holder()
 
@@ -119,6 +119,14 @@ class ServiceTestPolicyHolder(TestCase):
             "amount_notified": expected_amount_notified,
         }
         response = self.contract_service.update(contract)
+        updated_amount_notified = response['data']['amount_notified']
+
+        contract = {
+            "id": contract_id,
+        }
+        response = self.contract_service.delete(contract)
+        is_deleted = response['success']
+
         # tear down the test data
         ContractDetails.objects.filter(contract_id=contract_id).delete()
         Contract.objects.filter(id=contract_id).delete()
@@ -128,4 +136,7 @@ class ServiceTestPolicyHolder(TestCase):
         ContributionPlanBundle.objects.filter(id=contribution_plan_bundle.id).delete()
         ContributionPlan.objects.filter(id=contribution_plan.id).delete()
 
-        self.assertEqual(expected_amount_notified, response['data']['amount_notified'])
+        self.assertEqual(
+            (expected_amount_notified, True),
+            (updated_amount_notified, is_deleted)
+        )


### PR DESCRIPTION
IMPORTANT! This should be merged after accepting and merging this PR related to:
- 'delete contract' service 
- base mutation for ContractDetails, 
- both "update contract" mutation and service 
- add another perms in contract module.
#8, #9 and #10, #11, https://github.com/openimis/openimis-be-contract_py/pull/12 . Later after merging pull #8, #9, #10, #11, https://github.com/openimis/openimis-be-contract_py/pull/12 I will change the status of this pull request from "Draft" to the "Open".

The order of merging PR:
#8
#9
#10
#11
#12 
this one

In that PR I want to add the 'contract delete' mutation.