### PR TITLE
OFS-137: approve contract service

### DIFF
--- a/contract/gql/gql_mutations/contract_mutations.py
+++ b/contract/gql/gql_mutations/contract_mutations.py
@@ -1,9 +1,10 @@
 from core.gql.gql_mutations import DeleteInputType
 from core.gql.gql_mutations.base_mutation  import BaseMutation, BaseDeleteMutation
 from .mutations import ContractCreateMutationMixin, ContractUpdateMutationMixin, \
-    ContractDeleteMutationMixin
+    ContractDeleteMutationMixin, ContractSubmitMutationMixin
 from contract.models import Contract
-from contract.gql.gql_mutations.input_types import ContractCreateInputType, ContractUpdateInputType
+from contract.gql.gql_mutations.input_types import ContractCreateInputType, ContractUpdateInputType, \
+    ContractSubmitInputType
 
 
 class CreateContractMutation(ContractCreateMutationMixin, BaseMutation):
@@ -23,10 +24,20 @@ class UpdateContractMutation(ContractUpdateMutationMixin, BaseMutation):
     class Input(ContractUpdateInputType):
         pass
 
+
 class DeleteContractMutation(ContractDeleteMutationMixin, BaseDeleteMutation):
     _mutation_class = "DeleteContractMutation"
     _mutation_module = "contract"
     _model = Contract
 
     class Input(DeleteInputType):
+        pass
+
+
+class SubmitContractMutation(ContractSubmitMutationMixin, BaseMutation):
+    _mutation_class = "SubmitContractMutation"
+    _mutation_module = "contract"
+    _model = Contract
+
+    class Input(ContractSubmitInputType):
         pass

--- a/contract/gql/gql_mutations/input_types.py
+++ b/contract/gql/gql_mutations/input_types.py
@@ -42,6 +42,10 @@ class ContractUpdateInputType(OpenIMISMutation.Input):
     json_ext = graphene.types.json.JSONString(required=False)
 
 
+class ContractSubmitInputType(OpenIMISMutation.Input):
+    id = graphene.UUID(required=True)
+
+
 class ContractDetailsCreateInputType(OpenIMISMutation.Input):
     id = graphene.UUID(required=False)
     contract_id = graphene.UUID(required=True)

--- a/contract/gql/gql_mutations/mutations.py
+++ b/contract/gql/gql_mutations/mutations.py
@@ -89,3 +89,30 @@ class ContractDeleteMutationMixin:
         contract_service = ContractService(user=user)
         output_data = contract_service.delete(contract=contract)
         return output_data
+
+
+class ContractSubmitMutationMixin:
+
+    @property
+    def _model(self):
+        raise NotImplementedError()
+
+    @classmethod
+    def _validate_mutation(cls, user, **data):
+        if type(user) is AnonymousUser or not user.id or not user.has_perms(ContractConfig.gql_mutation_submit_contract_perms):
+            raise ValidationError("mutation.authentication_required")
+
+    @classmethod
+    def _mutate(cls, user, **data):
+        if "client_mutation_id" in data:
+            data.pop('client_mutation_id')
+        if "client_mutation_label" in data:
+            data.pop('client_mutation_label')
+        output = cls.submit_contract(user=user, contract=data)
+        return None if output["success"] else f"Error! - {output['message']}: {output['detail']}"
+
+    @classmethod
+    def submit_contract(cls, user, contract):
+        contract_service = ContractService(user=user)
+        output_data = contract_service.submit(contract=contract)
+        return output_data

--- a/contract/schema.py
+++ b/contract/schema.py
@@ -8,7 +8,7 @@ from contract.gql.gql_types import ContractGQLType, ContractDetailsGQLType, \
     ContractContributionPlanDetailsGQLType
 
 from contract.gql.gql_mutations.contract_mutations import CreateContractMutation, \
-    UpdateContractMutation, DeleteContractMutation
+    UpdateContractMutation, DeleteContractMutation, SubmitContractMutation
 from contract.gql.gql_mutations.contract_details_mutations import CreateContractDetailsMutation, \
     UpdateContractDetailsMutation, DeleteContractDetailsMutation
 
@@ -82,6 +82,7 @@ class Mutation(graphene.ObjectType):
     create_contract = CreateContractMutation.Field()
     update_contract = UpdateContractMutation.Field()
     delete_contract = DeleteContractMutation.Field()
+    submit_contract = SubmitContractMutation.Field()
 
     create_contract_details = CreateContractDetailsMutation.Field()
     update_contract_details = UpdateContractDetailsMutation.Field()

--- a/contract/services.py
+++ b/contract/services.py
@@ -421,10 +421,11 @@ class PaymentService(object):
         except Exception as exc:
             return _output_exception(
                 model_name="Payment",
-                method="createContribution",
+                method="createPayment",
                 exception=exc
             )
 
+    @check_authentication
     def collect_payment_details(self, contract_contribution_plan_details):
         payment_details_data = []
         for ccpd in contract_contribution_plan_details:

--- a/contract/signals.py
+++ b/contract/signals.py
@@ -5,24 +5,53 @@ from core.signals import Signal
 from django.core.serializers.json import DjangoJSONEncoder
 
 _contract_signal_params = ["contract", "user"]
+_contract_approve_signal_params = ["contract", "user", "contract_details_list", "service_object", "payment_service"]
 signal_contract = Signal(providing_args=_contract_signal_params)
+signal_contract_approve = Signal(providing_args=_contract_signal_params)
 
 
 def on_contract_signal(sender, **kwargs):
     contract = kwargs["contract"]
     user = kwargs["user"]
-    contract.save(username=user.username)
-    historical_record = contract.history.all().first()
-    contract.json_ext = json.dumps(__save_json_external(
-        user_id=historical_record.user_updated.id,
-        datetime=historical_record.date_updated,
-        message=f"contract updated - state {historical_record.state}"
-    ), cls=DjangoJSONEncoder)
-    contract.save(username=user.username)
+    __save_or_update_contract(contract=contract, user=user)
     return f"contract updated - state {contract.state}"
 
 
+def on_contract_approve_signal(sender, **kwargs):
+    # approve scenario
+    user = kwargs["user"]
+    contract_to_approve = kwargs["contract"]
+    contract_details_list = kwargs["contract_details_list"]
+    contract_service = kwargs["service_object"]
+    payment_service = kwargs["payment_service"]
+    # contract valuation
+    contract_contribution_plan_details = contract_service.evaluate_contract_valuation(
+        contract_details_result=contract_details_list,
+        save=True
+    )
+    contract_to_approve.amount_rectified = contract_contribution_plan_details["total_amount"]
+    from core import datetime
+    now = datetime.datetime.now()
+    # format payment data
+    payment_data = {
+        "expected_amount": contract_to_approve.amount_rectified,
+        "request_date": now,
+    }
+    payment_details_data = payment_service.collect_payment_details(contract_contribution_plan_details["contribution_plan_details"])
+    result_payment = payment_service.create(payment=payment_data, payment_details=payment_details_data)
+    # STATE_EXECUTABLE
+    contract_to_approve.state = 5
+    contract_to_approve.json_ext = json.dumps(
+        {"payment_uuid": result_payment["data"]["uuid"]},
+        cls=DjangoJSONEncoder
+    )
+    approved_contract = __save_or_update_contract(contract=contract_to_approve, user=user)
+    print(approved_contract)
+    return approved_contract
+
+
 signal_contract.connect(on_contract_signal, dispatch_uid="on_contract_signal")
+signal_contract_approve.connect(on_contract_approve_signal, dispatch_uid="on_contract_approve_signal")
 
 
 def __save_json_external(user_id, datetime, message):
@@ -34,3 +63,19 @@ def __save_json_external(user_id, datetime, message):
             "msg": message
         }]
     }
+
+
+def __save_or_update_contract(contract, user):
+    contract.save(username=user.username)
+    historical_record = contract.history.all().first()
+    contract.json_ext = json.dumps(__save_json_external(
+        user_id=historical_record.user_updated.id,
+        datetime=historical_record.date_updated,
+        message=f"contract updated - state {historical_record.state}"
+    ), cls=DjangoJSONEncoder)
+    print("saved")
+    contract.save(username=user.username)
+    return contract
+
+
+#def __create_paymen(contract)

--- a/contract/tests/helpers.py
+++ b/contract/tests/helpers.py
@@ -69,7 +69,7 @@ def create_test_contract_contribution_plan_details(contribution_plan=None, polic
 
     if not policy:
         policy = create_test_policy(
-            product=create_test_product("TestCode"),
+            product=create_test_product("TestCode", custom_props={"insurance_period": 12,}),
             insuree=create_test_insuree())
 
     if not contract_details:


### PR DESCRIPTION
In that PR I want to add approve contract service with OFS-143 - payment service - "createcontractPayment".

Things to develop later if we have configured SMTP server in openIMIS django app:
1. TO-DO - send payment notification via email - UC3-8: send payment notification by email 
2. TO-DO - UC4-6: assign a credit note to contract: On contract approval, if there is a credit note not assigned to a contract, it will be assigned to the newly approved contract as a payment.

IMPORTANT! It should be merged after this PR https://github.com/openimis/openimis-be-contract_py/pull/15