### PR TITLE
OFS-147: Terminate contract service

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Another payments are omitted in processing.
   - renew
   - delete
   - get_negative_amount_amendment
-  - terminate 
+  - terminate_contract 
 - ContractDetails
   - update_from_ph_insuree
   - ph_insuree_to_contract_details  

--- a/contract/services.py
+++ b/contract/services.py
@@ -435,6 +435,16 @@ class Contract(object):
                             f"{historical_record.state}"
                 ), cls=DjangoJSONEncoder)
                 contract_to_terminate.save(username=self.user.username)
+                return {
+                    "success": True,
+                    "message": "Ok",
+                    "detail": "",
+                }
+            return {
+                "success": False,
+                "message": "Cannot terminating contract!",
+                "detail": "This contract is still valid!",
+            }
         except Exception as exc:
             return _output_exception(model_name="Contract", method="terminateContract", exception=exc)
 


### PR DESCRIPTION
In that PR I want to add the last of service that should be implemented - terminate contract. 

https://openimis.atlassian.net/wiki/spaces/OP/pages/1730740273/Contract+Module
TerminateContract:
- previous contract of the (DateValidTo) will become “terminated“

Later we can as we talked we can reuse this service in apscheduler once a day as a task. 