### PR TITLE
OFS-212: connect calculation backend to the contract module

### DIFF
--- a/contract/services.py
+++ b/contract/services.py
@@ -651,37 +651,39 @@ class ContractContributionPlanDetails(object):
             total_amount = 0
             amendment = 0
             for contract_details in contract_contribution_plan_details["contract_details"]:
-                cpbd = ContributionPlanBundleDetails.objects.filter(
+                cpbd_list = ContributionPlanBundleDetails.objects.filter(
                     contribution_plan_bundle__id=str(contract_details["contribution_plan_bundle"])
-                )[0]
-                amendment = contract_details["amendment"]
-                ccpd = ContractContributionPlanDetailsModel(
-                    **{
-                        "contract_details_id": contract_details["id"],
-                        "contribution_plan_id": f"{cpbd.contribution_plan.id}",
-                        "policy_id": contract_details["policy_id"],
-                    }
                 )
-                # TODO here will be a function from calculation module
-                #  to count the value for amount. And now temporary value is here
-                #  until calculation module be developed
-                calculated_amount = 250
-                total_amount += calculated_amount
-                ccpd_record = model_to_dict(ccpd)
-                ccpd_record["calculated_amount"] = calculated_amount
-                if contract_contribution_plan_details["save"]:
-                    ccpd_list, total_amount, ccpd_record = self.__append_contract_cpd_to_list(
-                        ccpd=ccpd,
-                        cp=cpbd.contribution_plan,
-                        date_valid_from=contract_details["contract_date_valid_from"],
-                        insuree_id=contract_details["insuree_id"],
-                        total_amount=total_amount,
-                        calculated_amount=calculated_amount,
-                        ccpd_list=ccpd_list,
-                        ccpd_record=ccpd_record
+                amendment = contract_details["amendment"]
+                #cpbd = cpbd_list[0]
+                for cpbd in cpbd_list:
+                    ccpd = ContractContributionPlanDetailsModel(
+                        **{
+                            "contract_details_id": contract_details["id"],
+                            "contribution_plan_id": f"{cpbd.contribution_plan.id}",
+                            "policy_id": contract_details["policy_id"],
+                        }
                     )
-                if "id" not in ccpd_record:
-                    ccpd_list.append(ccpd_record)
+                    # TODO here will be a function from calculation module
+                    #  to count the value for amount. And now temporary value is here
+                    #  until calculation module be developed
+                    calculated_amount = 250
+                    total_amount += calculated_amount
+                    ccpd_record = model_to_dict(ccpd)
+                    ccpd_record["calculated_amount"] = calculated_amount
+                    if contract_contribution_plan_details["save"]:
+                        ccpd_list, total_amount, ccpd_record = self.__append_contract_cpd_to_list(
+                            ccpd=ccpd,
+                            cp=cpbd.contribution_plan,
+                            date_valid_from=contract_details["contract_date_valid_from"],
+                            insuree_id=contract_details["insuree_id"],
+                            total_amount=total_amount,
+                            calculated_amount=calculated_amount,
+                            ccpd_list=ccpd_list,
+                            ccpd_record=ccpd_record
+                        )
+                    if "id" not in ccpd_record:
+                        ccpd_list.append(ccpd_record)
             if amendment > 0:
                 # get the payment from the previous version of the contract
                 contract_detail_id = contract_contribution_plan_details["contract_details"][0]["id"]

--- a/contract/services.py
+++ b/contract/services.py
@@ -668,11 +668,12 @@ class ContractContributionPlanDetails(object):
                             "policy_id": contract_details["policy_id"],
                         }
                     )
-                    result_calculations = run_calculation_rules(ccpd, "create", self.user)
-                    from core import datetime, datetimedelta
+                    # rc - result of calculation
+                    calculated_amount = 0
+                    rc = run_calculation_rules(ccpd, "create", self.user)
                     length_contribution = cpbd.contribution_plan.get_contribution_length()
-                    if result_calculations:
-                        calculated_amount = sum([rc[1] * length_contribution if rc[1] not in [None, False] else 0 for rc in result_calculations])
+                    if rc:
+                        calculated_amount = rc[0][1] * length_contribution if rc[0][1] not in [None, False] else 0
                         total_amount += calculated_amount
                     ccpd_record = model_to_dict(ccpd)
                     ccpd_record["calculated_amount"] = calculated_amount
@@ -741,16 +742,14 @@ class ContractContributionPlanDetails(object):
         # case 2 - 2 contributions with 2 policies
         else:
             # there is additional contribution - we have to calculate/recalculate
-            # recalculate
             total_amount = total_amount - calculated_amount
             for ccpd_result in ccpd_results:
-                from core import datetime, datetimedelta
                 length_ccpd = (ccpd_result.date_valid_to.year - ccpd_result.date_valid_from.year) * 12 \
                               + (ccpd_result.date_valid_to.month - ccpd_result.date_valid_from.month)
-                result_calculations = run_calculation_rules(ccpd, "update", self.user)
                 # rc - result calculation
-                if result_calculations:
-                    calculated_amount = sum([rc[1] * length_ccpd if rc[1] not in [None, False] else 0 for rc in result_calculations])
+                rc = run_calculation_rules(ccpd, "update", self.user)
+                if rc:
+                    calculated_amount = rc[0][1] * length_ccpd if rc[0][1] not in [None, False] else 0
                     total_amount += calculated_amount
                 ccpd_record = model_to_dict(ccpd_result)
                 ccpd_record["calculated_amount"] = calculated_amount

--- a/contract/services.py
+++ b/contract/services.py
@@ -222,7 +222,7 @@ class Contract(object):
                 "id": f"{cd['id']}",
                 "contribution_plan_bundle": f"{cd['contribution_plan_bundle_id']}",
                 "policy_id": policy_id,
-                "json_ext": f"{cd['json_ext']}",
+                "json_ext": cd['json_ext'],
                 "contract_date_valid_from": contract_date_valid_from,
                 "insuree_id": cd['insuree_id'],
                 "amendment": amendment


### PR DESCRIPTION
TICKET - OFS-212 - https://openimis.atlassian.net/browse/OFS-212

Related PR (that PR should be merged first) - https://github.com/openimis/openimis-be-calculation_py/pull/8

In that PR I want to merge changes due to calculation module - now calculation of contract amount hasn't been hardcoded yet. Now amount is counted thanks to calculation rule of contribution (https://openimis.atlassian.net/wiki/spaces/OP/pages/2250473529/FS+calculation+rule+1+%3A++contribution+valuation) defined in calculation module. 
