### PR TITLE
OFS-241: changes in test - django test case instead of unittest.TestCase

### DIFF
--- a/contract/tests/gql_tests/mutation_create_tests.py
+++ b/contract/tests/gql_tests/mutation_create_tests.py
@@ -37,7 +37,7 @@ class MutationTestContract(TestCase):
         # create contribution plans etc
         cls.contribution_plan_bundle = create_test_contribution_plan_bundle()
         cls.contribution_plan = create_test_contribution_plan(
-            custom_props={"json_ext": '{"rate": "' + str(cls.rate) + '"}'}
+            custom_props={"json_ext": '{"calculation_rule":{"rate": "' + str(cls.rate) + '"}}'}
         )
         cls.contribution_plan_bundle_details = create_test_contribution_plan_bundle_details(
             contribution_plan=cls.contribution_plan,
@@ -51,7 +51,7 @@ class MutationTestContract(TestCase):
                 contribution_plan_bundle=cls.contribution_plan_bundle,
                 custom_props={
                     "last_policy": None,
-                    "json_ext": '{"income": "' + str(cls.income) + '"}'
+                    "json_ext": '{"calculation_rule":{"income": "' + str(cls.income) + '"}}'
                 }
             )
             create_test_policy(

--- a/contract/tests/gql_tests/query_tests.py
+++ b/contract/tests/gql_tests/query_tests.py
@@ -1,7 +1,8 @@
 import datetime
 import numbers
 import base64
-from unittest import TestCase, mock
+from unittest import mock
+from django.test import TestCase
 from uuid import UUID
 
 import graphene

--- a/contract/tests/helpers.py
+++ b/contract/tests/helpers.py
@@ -105,5 +105,7 @@ def create_test_contract_contribution_plan_details(contribution_plan=None, polic
 
 
 def __get_or_create_simple_contract_user():
-    user = User.objects.get(username="admin")
+    if not User.objects.filter(username='admin').exists():
+        User.objects.create_superuser(username='admin', password='S\/pe®Pąßw0rd™')
+    user = User.objects.filter(username='admin').first()
     return user

--- a/contract/tests/helpers_tests.py
+++ b/contract/tests/helpers_tests.py
@@ -1,5 +1,5 @@
 from functools import lru_cache
-from unittest import TestCase
+from django.test import TestCase
 
 from .helpers import *
 from ..models import ContractContributionPlanDetails

--- a/contract/tests/services/services_tests.py
+++ b/contract/tests/services/services_tests.py
@@ -30,7 +30,7 @@ class ServiceTestContract(TestCase):
         # create contribution plans etc
         cls.contribution_plan_bundle = create_test_contribution_plan_bundle()
         cls.contribution_plan = create_test_contribution_plan(
-            custom_props={"json_ext": '{"rate": "' + str(cls.rate) + '"}'}
+            custom_props={"json_ext": '{"calculation_rule":{"rate": "' + str(cls.rate) + '"}}'}
         )
         cls.contribution_plan_bundle_details = create_test_contribution_plan_bundle_details(
             contribution_plan=cls.contribution_plan,
@@ -44,7 +44,7 @@ class ServiceTestContract(TestCase):
                 contribution_plan_bundle=cls.contribution_plan_bundle,
                 custom_props={
                     "last_policy": None,
-                    "json_ext": '{"income": "' + str(cls.income) + '"}'
+                    "json_ext": '{"calculation_rule":{"income": "' + str(cls.income) + '"}}'
                 }
             )
             create_test_policy(
@@ -262,7 +262,6 @@ class ServiceTestContract(TestCase):
         contract = {"id": contract_id,}
         self.contract_service.submit(contract)
         self.contract_service.approve(contract)
-        self.contract_service.approve(contract)
         response = self.contract_service.amend(
             {
                 "id": contract_id,
@@ -286,7 +285,8 @@ class ServiceTestContract(TestCase):
         from core import datetime
         ph_insuree2 = create_test_policy_holder_insuree(
             policy_holder=self.policy_holder,
-            contribution_plan_bundle=self.contribution_plan_bundle
+            contribution_plan_bundle=self.contribution_plan_bundle,
+            custom_props={"last_policy": None, "json_ext": '{"calculation_rule":{"income": "400"}}'}
         )
         contract = {
             "code": "MTEST-1",
@@ -324,7 +324,7 @@ class CalculationContractTest(TestCase):
         # create contribution plans etc
         cls.contribution_plan_bundle = create_test_contribution_plan_bundle()
         cls.contribution_plan = create_test_contribution_plan(
-            custom_props={"json_ext": '{"rate": "' + str(cls.rate) + '"}'}
+            custom_props={"json_ext": '{"calculation_rule":{"rate": "' + str(cls.rate) + '"}}'}
         )
         cls.contribution_plan_bundle_details = create_test_contribution_plan_bundle_details(
             contribution_plan=cls.contribution_plan,
@@ -336,7 +336,7 @@ class CalculationContractTest(TestCase):
             create_test_policy_holder_insuree(
                 policy_holder=cls.policy_holder,
                 contribution_plan_bundle=cls.contribution_plan_bundle,
-                custom_props={"last_policy": None, "json_ext": '{"income": "' + str(cls.income) + '"}'}
+                custom_props={"last_policy": None, "json_ext": '{"calculation_rule":{"income": "' + str(cls.income) + '"}}'}
             )
 
     @classmethod


### PR DESCRIPTION
ticket https://openimis.atlassian.net/browse/OFS-241

changes in tests - change the TestCase (from django.TestCase) instead of using unittest.TestCase (to have test in separate test db to not keep records created during test etc)