### PR TITLE
OFS-246: changes in JSON email contact_name

### DIFF
--- a/contract/signals.py
+++ b/contract/signals.py
@@ -48,10 +48,13 @@ def on_contract_approve_signal(sender, **kwargs):
     contract_to_approve.date_approved = now
     contract_to_approve.state = 5
     approved_contract = __save_or_update_contract(contract=contract_to_approve, user=user)
+    email_contact_name = contract_to_approve.policy_holder.contact_name["contactName"] \
+        if "contactName" in contract_to_approve.policy_holder.contact_name \
+        else contract_to_approve.policy_holder.contact_name
     email = __send_email_notify_payment(
         code=contract_to_approve.code,
         name=contract_to_approve.policy_holder.trade_name,
-        contact_name=contract_to_approve.policy_holder.contact_name,
+        contact_name=email_contact_name,
         amount_due=contract_to_approve.amount_due,
         payment_reference=contract_to_approve.payment_reference,
         email=contract_to_approve.policy_holder.email,


### PR DESCRIPTION
In that PR I want to fix contactName on email during approving contract so as to not show
![Screenshot from 2021-03-11 12-50-59](https://user-images.githubusercontent.com/52816247/110951742-b0f8a780-8345-11eb-850c-a97586cbf339.png)
contact Name in JSON. example instead of {"contactName": "Michael Test"} - backend should in email display simply "Michael Test"