### PR TITLE
OFS-254: hotfix: copy json_ext from phi to cdetails during creating contract

### DIFF
--- a/contract/services.py
+++ b/contract/services.py
@@ -511,6 +511,7 @@ class ContractDetails(object):
                             "contract_id": contract_details["contract_id"],
                             "insuree_id": phi.insuree.id,
                             "contribution_plan_bundle_id": f"{phi.contribution_plan_bundle.id}",
+                            "json_ext": phi.json_ext,
                         }
                     )
                     cd.save(self.user)


### PR DESCRIPTION
In that PR I want to add json_ext copy during creating contract