### PR TITLE
OFS-280: Contract - add signal for dynamic mutation like in PH

### DIFF
--- a/contract/signals.py
+++ b/contract/signals.py
@@ -144,10 +144,6 @@ def append_contract_filter(sender, **kwargs):
                     return Q(
                         payment_details__premium__contract_contribution_plan_details__contract_details__contract__id=contract_id
                     )
-            else:
-                return Q(
-                    payment_details__premium__contract_contribution_plan_details__contract_details__contract__id=contract_id
-                )
 
 
 signal_before_payment_query.connect(append_contract_filter)

--- a/contract/signals.py
+++ b/contract/signals.py
@@ -67,8 +67,30 @@ def on_contract_approve_signal(sender, **kwargs):
     return approved_contract
 
 
+# additional filters for payment in 'contract' tab
+def append_contract_filter(sender, **kwargs):
+    user = kwargs.get("user", None)
+    additional_filter = kwargs.get('additional_filter', None)
+    if "contract" in additional_filter:
+        # then check perms
+        if user.has_perms(PaymentConfig.gql_query_payments_perms) or user.has_perms(PolicyholderConfig.gql_query_payment_portal_perms):
+            contract_id = additional_filter["contract"]
+            contract_to_process = Contract.objects.filter(id=contract_id).first()
+            # check if user is linked to ph in policy holder user table
+            type_user = f"{user}"
+            # related to user object output (i) or (t)
+            # check if we have interactive user from current context
+            if '(i)' in type_user:
+                ph_user = PolicyHolderUser.objects.filter(Q(policy_holder__id=contract_to_process.policy_holder.id, user__id=user.i_user.id)).first()
+                if ph_user or user.has_perms(PaymentConfig.gql_query_payments_perms):
+                    return Q(
+                        payment_details__premium__contract_contribution_plan_details__contract_details__contract__id=contract_id
+                    )
+
+
 signal_contract.connect(on_contract_signal, dispatch_uid="on_contract_signal")
 signal_contract_approve.connect(on_contract_approve_signal, dispatch_uid="on_contract_approve_signal")
+signal_before_payment_query.connect(append_contract_filter)
 
 
 @receiver(post_save, sender=Payment, dispatch_uid="payment_signal_paid")
@@ -123,30 +145,6 @@ def activate_contracted_policies(sender, instance, **kwargs):
                             )
                         contract.state = Contract.STATE_EFFECTIVE
                         __save_or_update_contract(contract, contract.user_updated)
-
-
-# additional filters for payment in 'contract' tab
-def append_contract_filter(sender, **kwargs):
-    user = kwargs.get("user", None)
-    additional_filter = kwargs.get('additional_filter', None)
-    if "contract" in additional_filter:
-        # then check perms
-        if user.has_perms(PaymentConfig.gql_query_payments_perms) or user.has_perms(PolicyholderConfig.gql_query_payment_portal_perms):
-            contract_id = additional_filter["contract"]
-            contract_to_process = Contract.objects.filter(id=contract_id).first()
-            # check if user is linked to ph in policy holder user table
-            type_user = f"{user}"
-            # related to user object output (i) or (t)
-            # check if we have interactive user from current context
-            if '(i)' in type_user:
-                ph_user = PolicyHolderUser.objects.filter(Q(policy_holder__id=contract_to_process.policy_holder.id, user__id=user.i_user.id)).first()
-                if ph_user:
-                    return Q(
-                        payment_details__premium__contract_contribution_plan_details__contract_details__contract__id=contract_id
-                    )
-
-
-signal_before_payment_query.connect(append_contract_filter)
 
 
 def __save_json_external(user_id, datetime, message):


### PR DESCRIPTION
TICKET: https://openimis.atlassian.net/browse/OFS-280

In that PR I want to add processing signal after passing additional filter into payment tab - "contract".

It works even with both args passing into filters.
![Screenshot from 2021-04-21 13-21-36](https://user-images.githubusercontent.com/52816247/115545855-939fed00-a2a4-11eb-9b55-18038bb24a17.png)
When I for example pass the contract id and policy holder id and policy holder is not related to the contract - the result of that query will be empty list.