### PR TITLE
OFS-292: fixed issue with copying insuree from PH to CD

### DIFF
--- a/contract/services.py
+++ b/contract/services.py
@@ -515,7 +515,7 @@ class ContractDetails(object):
                         }
                     )
                     # TODO add only the caclulation_rule section
-                    cd.save(self.user)
+                    cd.save(username=self.user.username)
                     uuid_string = f"{cd.id}"
                     dict_representation = model_to_dict(cd)
                     dict_representation["id"], dict_representation["uuid"] = (uuid_string, uuid_string)
@@ -553,7 +553,7 @@ class ContractDetails(object):
                         "contribution_plan_bundle_id": f"{phi.contribution_plan_bundle.id}",
                     }
                 )
-                cd.save(self.user)
+                cd.save(username=self.user.username)
                 uuid_string = f"{cd.id}"
                 dict_representation = model_to_dict(cd)
                 dict_representation["id"], dict_representation["uuid"] = (uuid_string, uuid_string)


### PR DESCRIPTION
TICKET: https://openimis.atlassian.net/browse/OFS-292

part related to third point "3. Fix copying insuree from PolicyHolder to ContractDetails in contract services related to processing contract details. "