### PR TITLE
Test Technical user mixed tech and core users

### DIFF
--- a/contract/services.py
+++ b/contract/services.py
@@ -1,11 +1,9 @@
 import json
-import uuid
-import traceback
 
 from copy import copy
 from .config import get_message_counter_contract
 
-from django.db.models.query import QuerySet, Q
+from django.db.models.query import Q
 from django.conf import settings
 from django.contrib.auth.models import AnonymousUser
 from django.core.serializers.json import DjangoJSONEncoder
@@ -20,7 +18,7 @@ from contract.models import Contract as ContractModel, \
 from calculation.services import run_calculation_rules
 
 from policyholder.models import PolicyHolderInsuree
-from contribution.models import Premium, Payer
+from contribution.models import Premium
 from contribution_plan.models import ContributionPlanBundleDetails, ContributionPlan
 
 from policy.models import Policy
@@ -243,7 +241,7 @@ class Contract(object):
             # variable to check if we have right to approve
             state_right = self.__check_rights_by_status(contract_to_approve.state)
             # check if we can submit
-            if state_right is not "approvable":
+            if state_right != "approvable":
                 raise ContractUpdateError("You cannot approve this contract! The status of contract is not Negotiable!")
             contract_details_list = {}
             contract_details_list["data"] = self.__gather_policy_holder_insuree(
@@ -282,7 +280,7 @@ class Contract(object):
             # variable to check if we have right to approve
             state_right = self.__check_rights_by_status(contract_to_counter.state)
             # check if we can submit
-            if state_right is not "approvable":
+            if state_right != "approvable":
                 raise ContractUpdateError("You cannot counter this contract! The status of contract is not Negotiable!")
             contract_to_counter.state = ContractModel.STATE_COUNTER
             signal_contract.send(sender=ContractModel, contract=contract_to_counter, user=self.user)
@@ -309,7 +307,7 @@ class Contract(object):
             # variable to check if we have right to amend contract
             state_right = self.__check_rights_by_status(contract_to_amend.state)
             # check if we can amend
-            if state_right is not "cannot_update" and contract_to_amend.state is not ContractModel.STATE_TERMINATED:
+            if state_right != "cannot_update" and contract_to_amend.state != ContractModel.STATE_TERMINATED:
                 raise ContractUpdateError("You cannot amend this contract!")
             # create copy of the contract
             amended_contract = copy(contract_to_amend)

--- a/contract/services.py
+++ b/contract/services.py
@@ -28,6 +28,10 @@ from insuree.models import Insuree
 
 from core.signals import *
 
+import logging
+
+logger = logging.getLogger(__file__)
+
 
 class ContractUpdateError(Exception):
 
@@ -101,6 +105,9 @@ class Contract(object):
                 "save": save,
             }
         )
+        if not result_contract_valuation or result_contract_valuation["success"] is False:
+            logger.error("contract valuation failed %s", result_contract_valuation)
+            raise Exception("contract valuation failed " + result_contract_valuation)
         return result_contract_valuation["data"]
 
     # TODO update contract scenario according to wiki page
@@ -505,7 +512,7 @@ class ContractDetails(object):
             )
             for phi in policy_holder_insuree:
                 # TODO add the validity condition also!
-                if phi.is_deleted == False and phi.contribution_plan_bundle:
+                if phi.is_deleted is False and phi.contribution_plan_bundle:
                     cd = ContractDetailsModel(
                         **{
                             "contract_id": contract_details["contract_id"],

--- a/contract/tests/gql_tests/mutation_create_tests.py
+++ b/contract/tests/gql_tests/mutation_create_tests.py
@@ -8,6 +8,7 @@ from uuid import UUID
 import graphene
 from contract.tests.helpers import *
 from contract.models import Contract, ContractDetails
+from core.test_helpers import create_test_technical_user
 from policyholder.tests.helpers import *
 from contribution_plan.tests.helpers import create_test_contribution_plan, \
     create_test_contribution_plan_bundle, create_test_contribution_plan_bundle_details
@@ -29,8 +30,9 @@ class MutationTestContract(TestCase):
 
     @classmethod
     def setUpClass(cls):
-        if not User.objects.filter(username='admin').exists():
-            User.objects.create_superuser(username='admin', password='S\/pe®Pąßw0rd™')
+        if not TechnicalUser.objects.filter(username='admin').exists():
+            #User.objects.create_superuser(username='admin', password='S\/pe®Pąßw0rd™')
+            create_test_technical_user(username='admin', password='S\/pe®Pąßw0rd™', super_user=True)
         cls.user = User.objects.filter(username='admin').first()
         # some test data so as to created contract properly
         cls.income = 500

--- a/contract/tests/gql_tests/mutation_create_tests.py
+++ b/contract/tests/gql_tests/mutation_create_tests.py
@@ -31,7 +31,6 @@ class MutationTestContract(TestCase):
     @classmethod
     def setUpClass(cls):
         if not TechnicalUser.objects.filter(username='admin').exists():
-            #User.objects.create_superuser(username='admin', password='S\/pe®Pąßw0rd™')
             create_test_technical_user(username='admin', password='S\/pe®Pąßw0rd™', super_user=True)
         cls.user = User.objects.filter(username='admin').first()
         # some test data so as to created contract properly

--- a/contract/tests/services/services_tests.py
+++ b/contract/tests/services/services_tests.py
@@ -2,6 +2,7 @@ from django.test import TestCase
 from contract.services import Contract as ContractService, ContractDetails as ContractDetailsService, \
     ContractContributionPlanDetails as ContractContributionPlanDetailsService
 from contract.models import Contract, ContractDetails, ContractContributionPlanDetails
+from core.test_helpers import create_test_technical_user
 from policyholder.models import PolicyHolder, PolicyHolderInsuree
 from policyholder.tests.helpers import create_test_policy_holder, create_test_policy_holder_insuree
 from contribution_plan.tests.helpers import create_test_contribution_plan, \
@@ -14,12 +15,13 @@ from calculation.services import get_parameters, get_rule_details, \
 
 
 class ServiceTestContract(TestCase):
+    user = None
 
     @classmethod
     def setUpClass(cls):
-        if not User.objects.filter(username='admin').exists():
-            User.objects.create_superuser(username='admin', password='S\/pe®Pąßw0rd™')
         cls.user = User.objects.filter(username='admin').first()
+        if not cls.user:
+            cls.user = create_test_technical_user(username='admin', password='S\/pe®Pąßw0rd™', super_user=True)
         cls.contract_service = ContractService(cls.user)
         cls.contract_details_service = ContractDetailsService(cls.user)
         cls.contract_contribution_plan_details_service = ContractContributionPlanDetailsService(cls.user)
@@ -306,12 +308,13 @@ class ServiceTestContract(TestCase):
 
 
 class CalculationContractTest(TestCase):
+    user = None
 
     @classmethod
     def setUpClass(cls):
-        if not User.objects.filter(username='admin').exists():
-            User.objects.create_superuser(username='admin', password='S\/pe®Pąßw0rd™')
         cls.user = User.objects.filter(username='admin').first()
+        if not cls.user:
+            cls.user = create_test_technical_user(username='admin', password='S\/pe®Pąßw0rd™', super_user=True)
         cls.contract_service = ContractService(cls.user)
         cls.income = 500
         cls.rate = 5


### PR DESCRIPTION
This requires an update of the core for the test helper.

The `if not User.objects.filter(username='admin').exists():` was creating a technical user and then fetching a core user with the same username. Instead of just creating the core user, I added a test helper for technical (super) users and this works a lot better.

The main project had many test failures because of this.