### PR TITLE
fix: normalize date types in subtract_date_ranges

### DIFF
--- a/contract/services.py
+++ b/contract/services.py
@@ -7,7 +7,7 @@ from decimal import Decimal
 
 from calculation.services import run_calculation_rules
 from contribution.models import Premium
-from core import datetime, datetimedelta
+from core import datetime, datetimedelta, to_date, subtract_date_ranges
 from core.signals import register_service_signal
 from dateutil.relativedelta import relativedelta
 from django.conf import settings
@@ -1090,44 +1090,3 @@ def check_unique_code(code):
     if ContractModel.objects.filter(code=code, is_deleted=False).exists():
         return [{"message": _("Contract code %s already exists" % code)}]
     return []
-
-
-def _to_date(d):
-    # Normalize datetime (with time component) to date.
-    # AdDate.to_ad_date() returns self; AdDatetime.to_ad_date() returns AdDate.
-    if hasattr(d, 'to_ad_date'):
-        return d.to_ad_date()
-    # Plain datetime.datetime has .date(); plain datetime.date does not.
-    if hasattr(d, 'date') and callable(d.date):
-        return d.date()
-    return d
-
-
-def subtract_date_ranges(main_range, date_ranges):
-    main_start = _to_date(main_range[0])
-    main_end = _to_date(main_range[1])
-    result = []
-    current = main_start
-
-    # Sort the date ranges
-    sorted_ranges = sorted(date_ranges, key=lambda x: _to_date(x[0]))
-
-    for start, end in sorted_ranges:
-        start = _to_date(start)
-        end = _to_date(end)
-        # If there's a gap before the current range, add it to the result
-        if current < start:
-            result.append((current, min(start, main_end)))
-
-        # Move the current pointer
-        current = max(current, end)
-
-        # If we've covered the entire main range, break
-        if current >= main_end:
-            break
-
-    # If there's remaining uncovered time after the last range, add it
-    if current < main_end:
-        result.append((current, main_end))
-
-    return result

--- a/contract/services.py
+++ b/contract/services.py
@@ -7,7 +7,7 @@ from decimal import Decimal
 
 from calculation.services import run_calculation_rules
 from contribution.models import Premium
-from core import datetime, datetimedelta, subtract_date_ranges
+from core import datetime, datetimedelta
 from core.signals import register_service_signal
 from dateutil.relativedelta import relativedelta
 from django.conf import settings
@@ -1090,3 +1090,39 @@ def check_unique_code(code):
     if ContractModel.objects.filter(code=code, is_deleted=False).exists():
         return [{"message": _("Contract code %s already exists" % code)}]
     return []
+
+
+def _to_date(d):
+    # Normalize datetime (with time component) to date.
+    # AdDate.to_ad_date() returns self; AdDatetime.to_ad_date() returns AdDate.
+    if hasattr(d, 'to_ad_date'):
+        return d.to_ad_date()
+    # Plain datetime.datetime has .date(); plain datetime.date does not.
+    if hasattr(d, 'date') and callable(d.date):
+        return d.date()
+    return d
+
+
+def subtract_date_ranges(main_range, date_ranges):
+    main_start = _to_date(main_range[0])
+    main_end = _to_date(main_range[1])
+    result = []
+    current = main_start
+
+    sorted_ranges = sorted(date_ranges, key=lambda x: _to_date(x[0]))
+
+    for start, end in sorted_ranges:
+        start = _to_date(start)
+        end = _to_date(end)
+        if current < start:
+            result.append((current, min(start, main_end)))
+
+        current = max(current, end)
+
+        if current >= main_end:
+            break
+
+    if current < main_end:
+        result.append((current, main_end))
+
+    return result

--- a/contract/services.py
+++ b/contract/services.py
@@ -7,7 +7,7 @@ from decimal import Decimal
 
 from calculation.services import run_calculation_rules
 from contribution.models import Premium
-from core import datetime, datetimedelta, to_date, subtract_date_ranges
+from core import datetime, datetimedelta, subtract_date_ranges
 from core.signals import register_service_signal
 from dateutil.relativedelta import relativedelta
 from django.conf import settings

--- a/contract/services.py
+++ b/contract/services.py
@@ -1092,15 +1092,29 @@ def check_unique_code(code):
     return []
 
 
+def _to_date(d):
+    # Normalize datetime (with time component) to date.
+    # AdDate.to_ad_date() returns self; AdDatetime.to_ad_date() returns AdDate.
+    if hasattr(d, 'to_ad_date'):
+        return d.to_ad_date()
+    # Plain datetime.datetime has .date(); plain datetime.date does not.
+    if hasattr(d, 'date') and callable(d.date):
+        return d.date()
+    return d
+
+
 def subtract_date_ranges(main_range, date_ranges):
-    main_start, main_end = main_range
+    main_start = _to_date(main_range[0])
+    main_end = _to_date(main_range[1])
     result = []
     current = main_start
 
     # Sort the date ranges
-    sorted_ranges = sorted(date_ranges, key=lambda x: x[0])
+    sorted_ranges = sorted(date_ranges, key=lambda x: _to_date(x[0]))
 
     for start, end in sorted_ranges:
+        start = _to_date(start)
+        end = _to_date(end)
         # If there's a gap before the current range, add it to the result
         if current < start:
             result.append((current, min(start, main_end)))

--- a/contract/services.py
+++ b/contract/services.py
@@ -7,7 +7,7 @@ from decimal import Decimal
 
 from calculation.services import run_calculation_rules
 from contribution.models import Premium
-from core import datetime, datetimedelta
+from core import datetime, datetimedelta, subtract_date_ranges
 from core.signals import register_service_signal
 from dateutil.relativedelta import relativedelta
 from django.conf import settings
@@ -1090,39 +1090,3 @@ def check_unique_code(code):
     if ContractModel.objects.filter(code=code, is_deleted=False).exists():
         return [{"message": _("Contract code %s already exists" % code)}]
     return []
-
-
-def _to_date(d):
-    # Normalize datetime (with time component) to date.
-    # AdDate.to_ad_date() returns self; AdDatetime.to_ad_date() returns AdDate.
-    if hasattr(d, 'to_ad_date'):
-        return d.to_ad_date()
-    # Plain datetime.datetime has .date(); plain datetime.date does not.
-    if hasattr(d, 'date') and callable(d.date):
-        return d.date()
-    return d
-
-
-def subtract_date_ranges(main_range, date_ranges):
-    main_start = _to_date(main_range[0])
-    main_end = _to_date(main_range[1])
-    result = []
-    current = main_start
-
-    sorted_ranges = sorted(date_ranges, key=lambda x: _to_date(x[0]))
-
-    for start, end in sorted_ranges:
-        start = _to_date(start)
-        end = _to_date(end)
-        if current < start:
-            result.append((current, min(start, main_end)))
-
-        current = max(current, end)
-
-        if current >= main_end:
-            break
-
-    if current < main_end:
-        result.append((current, main_end))
-
-    return result

--- a/contract/tests/test_mutation_create_tests.py
+++ b/contract/tests/test_mutation_create_tests.py
@@ -23,7 +23,7 @@ from policyholder.tests.helpers import (
 from policyholder.models import PolicyHolderUser
 from contract import schema as contract_schema
 from contract.models import Contract, ContractContributionPlanDetails
-from contract.services import subtract_date_ranges
+from core import subtract_date_ranges
 from contract.signals import append_contract_filter
 from payment.models import Payment
 from insuree.models import InsureePolicy

--- a/contract/tests/test_mutation_create_tests.py
+++ b/contract/tests/test_mutation_create_tests.py
@@ -23,7 +23,7 @@ from policyholder.tests.helpers import (
 from policyholder.models import PolicyHolderUser
 from contract import schema as contract_schema
 from contract.models import Contract, ContractContributionPlanDetails
-from core import subtract_date_ranges
+from contract.services import subtract_date_ranges
 from contract.signals import append_contract_filter
 from payment.models import Payment
 from insuree.models import InsureePolicy

--- a/contract/tests/test_services.py
+++ b/contract/tests/test_services.py
@@ -26,7 +26,7 @@ from contract.services import (
     ContractContributionPlanDetails as ContractContributionPlanDetailsService,
 )
 from contract.services import ContractDetails as ContractDetailsService
-from core import subtract_date_ranges
+from contract.services import subtract_date_ranges
 
 
 class ServiceTestContract(TestCase):

--- a/contract/tests/test_services.py
+++ b/contract/tests/test_services.py
@@ -26,7 +26,7 @@ from contract.services import (
     ContractContributionPlanDetails as ContractContributionPlanDetailsService,
 )
 from contract.services import ContractDetails as ContractDetailsService
-from contract.services import subtract_date_ranges
+from core import subtract_date_ranges
 
 
 class ServiceTestContract(TestCase):


### PR DESCRIPTION
## Summary

- `contract.date_valid_from` is a `DateTimeField` which returns `AdDatetime` (a `datetime.datetime` subclass) from the DB
- `InsureePolicy.effective_date` is a `DateField` which returns `AdDate` (a `datetime.date` subclass)
- `subtract_date_ranges` compared them directly, raising `TypeError: can't compare datetime.datetime to AdDate`

Adds a `_to_date()` normalizer that strips the time component from any datetime variant (`AdDatetime`, plain `datetime.datetime`) while leaving date objects (`AdDate`, `datetime.date`) unchanged. Applied to all inputs and loop variables inside `subtract_date_ranges`.

## Root cause

This was one of several pre-existing failures causing the "Run All Tests" job to fail across all module PRs in the openimis project.