### PR TITLE
fix(contract): normalize dates in subtract_date_ranges using to_date()

### DIFF
--- a/contract/services.py
+++ b/contract/services.py
@@ -1093,12 +1093,17 @@ def check_unique_code(code):
 
 
 def subtract_date_ranges(main_range, date_ranges):
-    main_start, main_end = main_range
+    from core.datetimes.shared import to_date
+
+    main_start, main_end = (to_date(main_range[0]), to_date(main_range[1]))
     result = []
     current = main_start
 
     # Sort the date ranges
-    sorted_ranges = sorted(date_ranges, key=lambda x: x[0])
+    sorted_ranges = sorted(
+        [(to_date(start), to_date(end)) for start, end in date_ranges],
+        key=lambda x: x[0],
+    )
 
     for start, end in sorted_ranges:
         # If there's a gap before the current range, add it to the result


### PR DESCRIPTION
Convert date range values to plain date objects via `to_date()` before performing subtraction logic in `subtract_date_ranges`. This ensures consistent date type handling and prevents comparison errors when inputs are datetime or string types rather than plain date objects.

#Thank you for your contribution to openIMIS!
#Please complete the sections below. Anything in comments is guidance and can be deleted.

# Description

A clear, concise description of the change. Why is it needed? What problem does it solve?

# Type of Change

- [ ] Feature
- [ ] Bug fix
- [ ] Chore (Refactor, Docs, CI/CD)
- [ ] Other, please specify

## Related Issue(s) / Task(s)
- [ ] Requires [link to github PR], [link to github PR] needs to be merged first before this one
- [ ] Relates to [link to github PR], this needs to be merged before [link to github PR]
- [ ] External reference (e.g., Jira):

## Demo

Upload screenshots/gifs or link to any demo video here.

## Checklist
- [ ] Unit tests added/modified
- [ ] I18n / translation handled
