### PR TITLE
feat(contract): Expose contractDetails and contractContributionPlanDetails in contract query with DataLoader optimization

### DIFF
--- a/contract/apps.py
+++ b/contract/apps.py
@@ -61,3 +61,14 @@ class ContractConfig(AppConfig):
 
         cfg = ModuleConfiguration.get_or_default(MODULE_NAME, DEFAULT_CFG)
         self.__load_config(cfg)
+
+    def set_dataloaders(self, dataloaders):
+        from contract.dataloaders import (
+            ContractDetailsByContractLoader,
+            ContributionPlanDetailsByContractLoader,
+        )
+
+        dataloaders["contract_details_by_contract"] = ContractDetailsByContractLoader()
+        dataloaders["contract_contribution_plan_details_by_contract"] = (
+            ContributionPlanDetailsByContractLoader()
+        )

--- a/contract/dataloaders.py
+++ b/contract/dataloaders.py
@@ -1,0 +1,47 @@
+from collections import defaultdict
+
+from promise import Promise
+from promise.dataloader import DataLoader
+
+from contract.models import ContractDetails, ContractContributionPlanDetails
+
+
+class ContractDetailsByContractLoader(DataLoader):
+    def batch_load_fn(self, contract_ids):
+        grouped = defaultdict(list)
+
+        details = (
+            ContractDetails.objects
+            .filter(contract_id__in=contract_ids, is_deleted=False)
+            .select_related("insuree", "contribution_plan_bundle")
+            .order_by("id")
+        )
+
+        for detail in details:
+            grouped[detail.contract_id].append(detail)
+
+        return Promise.resolve([grouped.get(contract_id, []) for contract_id in contract_ids])
+
+
+class ContributionPlanDetailsByContractLoader(DataLoader):
+    def batch_load_fn(self, contract_ids):
+        grouped = defaultdict(list)
+
+        rows = (
+            ContractContributionPlanDetails.objects
+            .filter(contract_details__contract_id__in=contract_ids, is_deleted=False)
+            .select_related(
+                "contract_details",
+                "contract_details__insuree",
+                "contract_details__contribution_plan_bundle",
+                "contribution_plan",
+                "contribution",
+                "policy",
+            )
+            .order_by("id")
+        )
+
+        for row in rows:
+            grouped[row.contract_details.contract_id].append(row)
+
+        return Promise.resolve([grouped.get(contract_id, []) for contract_id in contract_ids])

--- a/contract/gql/gql_types.py
+++ b/contract/gql/gql_types.py
@@ -19,6 +19,10 @@ from contract.models import (
 
 
 class ContractGQLType(DjangoObjectType):
+    contract_details = graphene.List(lambda: ContractDetailsGQLType)
+    contract_contribution_plan_details = graphene.List(
+        lambda: ContractContributionPlanDetailsGQLType
+    )
 
     class Meta:
         model = Contract
@@ -47,6 +51,32 @@ class ContractGQLType(DjangoObjectType):
         @classmethod
         def get_queryset(cls, queryset, info):
             return Contract.get_queryset(queryset, info)
+
+    def resolve_contract_details(self, info):
+        loader = getattr(info.context, "dataloaders", {}).get(
+            "contract_details_by_contract"
+        )
+        if loader:
+            return loader.load(self.id)
+
+        return (
+            ContractDetails.objects
+            .filter(contract_id=self.id, is_deleted=False)
+            .select_related("insuree", "contribution_plan_bundle")
+        )
+
+    def resolve_contract_contribution_plan_details(self, info):
+        loader = getattr(info.context, "dataloaders", {}).get(
+            "contract_contribution_plan_details_by_contract"
+        )
+        if loader:
+            return loader.load(self.id)
+
+        return (
+            ContractContributionPlanDetails.objects
+            .filter(contract_details__contract_id=self.id, is_deleted=False)
+            .select_related("contract_details", "contribution_plan", "contribution", "policy")
+        )
 
     # amount = graphene.Float()
 

--- a/contract/tests/test_dataloaders.py
+++ b/contract/tests/test_dataloaders.py
@@ -1,0 +1,151 @@
+from django.test import TestCase
+
+from contract.dataloaders import (
+    ContractDetailsByContractLoader,
+    ContributionPlanDetailsByContractLoader,
+)
+from contract.models import ContractContributionPlanDetails, ContractDetails
+from contract.tests.helpers import (
+    create_test_contract,
+    create_test_contract_contribution_plan_details,
+    create_test_contract_details,
+)
+
+
+class ContractDetailsByContractLoaderTest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.first_contract = create_test_contract()
+        cls.second_contract = create_test_contract()
+        cls.empty_contract = create_test_contract()
+
+        cls.first_detail = create_test_contract_details(
+            contract=cls.first_contract
+        )
+        cls.second_detail = create_test_contract_details(
+            contract=cls.first_contract,
+            insuree=cls.first_detail.insuree,
+            contribution_plan_bundle=cls.first_detail.contribution_plan_bundle,
+        )
+        cls.other_contract_detail = create_test_contract_details(
+            contract=cls.second_contract,
+            insuree=cls.first_detail.insuree,
+            contribution_plan_bundle=cls.first_detail.contribution_plan_bundle,
+        )
+        cls.deleted_detail = create_test_contract_details(
+            contract=cls.first_contract,
+            insuree=cls.first_detail.insuree,
+            contribution_plan_bundle=cls.first_detail.contribution_plan_bundle,
+        )
+        ContractDetails.objects.filter(pk=cls.deleted_detail.pk).update(
+            is_deleted=True
+        )
+
+    def test_batch_load_groups_results_in_key_order_and_excludes_deleted(self):
+        contract_ids = [
+            self.second_contract.id,
+            self.empty_contract.id,
+            self.first_contract.id,
+        ]
+
+        with self.assertNumQueries(1):
+            results = ContractDetailsByContractLoader().batch_load_fn(
+                contract_ids
+            ).get()
+
+        self.assertEqual(
+            [[detail.id for detail in group] for group in results],
+            [
+                [self.other_contract_detail.id],
+                [],
+                sorted([self.first_detail.id, self.second_detail.id]),
+            ],
+        )
+
+    def test_batch_load_selects_related_objects(self):
+        with self.assertNumQueries(1):
+            results = ContractDetailsByContractLoader().batch_load_fn(
+                [self.first_contract.id]
+            ).get()
+            for detail in results[0]:
+                detail.insuree
+                detail.contribution_plan_bundle
+
+
+class ContributionPlanDetailsLoaderTest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.first_contract = create_test_contract()
+        cls.second_contract = create_test_contract()
+        cls.empty_contract = create_test_contract()
+
+        cls.first_contract_detail = create_test_contract_details(
+            contract=cls.first_contract
+        )
+        cls.second_contract_detail = create_test_contract_details(
+            contract=cls.second_contract,
+            insuree=cls.first_contract_detail.insuree,
+            contribution_plan_bundle=(
+                cls.first_contract_detail.contribution_plan_bundle
+            ),
+        )
+
+        cls.first_row = create_test_contract_contribution_plan_details(
+            contract_details=cls.first_contract_detail
+        )
+        shared_relations = {
+            "contribution_plan": cls.first_row.contribution_plan,
+            "policy": cls.first_row.policy,
+            "contribution": cls.first_row.contribution,
+        }
+        cls.second_row = create_test_contract_contribution_plan_details(
+            contract_details=cls.first_contract_detail,
+            **shared_relations,
+        )
+        cls.other_contract_row = (
+            create_test_contract_contribution_plan_details(
+                contract_details=cls.second_contract_detail,
+                **shared_relations,
+            )
+        )
+        cls.deleted_row = create_test_contract_contribution_plan_details(
+            contract_details=cls.first_contract_detail,
+            **shared_relations,
+        )
+        ContractContributionPlanDetails.objects.filter(
+            pk=cls.deleted_row.pk
+        ).update(is_deleted=True)
+
+    def test_batch_load_groups_results_in_key_order_and_excludes_deleted(self):
+        contract_ids = [
+            self.second_contract.id,
+            self.empty_contract.id,
+            self.first_contract.id,
+        ]
+
+        with self.assertNumQueries(1):
+            results = ContributionPlanDetailsByContractLoader().batch_load_fn(
+                contract_ids
+            ).get()
+
+        self.assertEqual(
+            [[row.id for row in group] for group in results],
+            [
+                [self.other_contract_row.id],
+                [],
+                sorted([self.first_row.id, self.second_row.id]),
+            ],
+        )
+
+    def test_batch_load_selects_related_objects(self):
+        with self.assertNumQueries(1):
+            results = ContributionPlanDetailsByContractLoader().batch_load_fn(
+                [self.first_contract.id]
+            ).get()
+            for row in results[0]:
+                row.contract_details
+                row.contract_details.insuree
+                row.contract_details.contribution_plan_bundle
+                row.contribution_plan
+                row.contribution
+                row.policy

--- a/contract/tests/tests_gql_query.py
+++ b/contract/tests/tests_gql_query.py
@@ -728,3 +728,73 @@ class ContractQueryTest(openIMISGraphQLTestCase):
 
         params_as_args = [f"{k}:{wrap_arg(v)}" for k, v in params.items()]
         return ", ".join(params_as_args)
+
+    def test_find_contract_with_contract_details(self):
+        contract_id = self.test_contract.id
+        contract_detail_id = self.test_contract_details.id
+
+        query = f"""
+        {{
+            contract(id: "{contract_id}") {{
+                totalCount
+                edges {{
+                    node {{
+                        id
+                        contractDetails {{
+                            id
+                            insuree {{
+                                id
+                            }}
+                            contributionPlanBundle {{
+                                id
+                            }}
+                        }}
+                    }}
+                }}
+            }}
+        }}
+        """
+
+        query_result = self.execute_query(query)
+        result = query_result["contract"]["edges"][0]["node"]
+
+        self.assertTrue(result["contractDetails"])
+        returned_id = base64.b64decode(
+            result["contractDetails"][0]["id"]
+        ).decode("utf-8").split(":")[1]
+
+        self.assertEqual(UUID(returned_id), contract_detail_id)
+
+    def test_find_contract_with_contract_contribution_plan_details(self):
+        contract_id = self.test_contract.id
+        contribution_detail_id = self.test_contract_contribution_plan_details.id
+
+        query = f"""
+        {{
+            contract(id: "{contract_id}") {{
+                totalCount
+                edges {{
+                    node {{
+                        id
+                        contractContributionPlanDetails {{
+                            id
+                            amount
+                            contributionPlan {{
+                                id
+                            }}
+                        }}
+                    }}
+                }}
+            }}
+        }}
+        """
+
+        query_result = self.execute_query(query)
+        result = query_result["contract"]["edges"][0]["node"]
+
+        self.assertTrue(result["contractContributionPlanDetails"])
+        returned_id = base64.b64decode(
+            result["contractContributionPlanDetails"][0]["id"]
+        ).decode("utf-8").split(":")[1]
+
+        self.assertEqual(UUID(returned_id), contribution_detail_id)


### PR DESCRIPTION
# Description

This PR addresses the issue where `contractDetails` and `contractContributionPlanDetails` fields were not exposed in the GraphQL `contract` query. Previously, these fields were only accessible via separate queries, and mutations `update` generated N+1 SQL queries. We implemented DataLoaders to batch-load these relations efficiently, reducing the number of database queries and improving API performance. The new fields are now available directly in the `contract` query response, allowing the frontend to fetch all contract data in a single GraphQL request.

# Type of Change

- [x] Feature
- [ ] Bug fix
- [ ] Chore (Refactor, Docs, CI/CD)
- [ ] Other, please specify

## Related Issue(s) / Task(s)
- [ ] Requires [link to github PR]
- [ ] Relates to [link to github PR]
- [x] External reference: Ticket Jira https://openimis.atlassian.net/browse/OP-3017

## Demo

```graphql
{
  contract(code: "CONTRACT_001") {
    edges {
      node {
        id
        code
        contractDetails {
          id
          insuree { id chfId lastName }
          contributionPlanBundle { id code }
        }
        contractContributionPlanDetails {
          id
          amount
          contributionPlan { id code }
        }
      }
    }
  }
}
```

## Checklist
- [x] Unit tests added/modified
- [ ] I18n / translation handled
- [x] DataLoaders implemented for performance optimization
- [x] No N+1 queries in contract query